### PR TITLE
Adding support to handle a sarif endpoint to send the report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 .nyc_output
 config.js
 package-lock.json
+output.sarif.json

--- a/endpoint/README.md
+++ b/endpoint/README.md
@@ -2,5 +2,11 @@
 
 ```bash
 npm install
-npm start
+npm start 
+```
+
+Now we can run cloud sploit to generate the data.
+
+```bash
+node index.js --cloud aws --config ./config.js --json=output.sarif.json --plugin s3Encryption --sarifEndpoint=http://localhost:3000
 ```

--- a/endpoint/README.md
+++ b/endpoint/README.md
@@ -1,0 +1,6 @@
+## Run Cloud Functions locally
+
+```bash
+npm install
+npm start
+```

--- a/endpoint/index.js
+++ b/endpoint/index.js
@@ -1,0 +1,39 @@
+const functions = require('@google-cloud/functions-framework');
+
+const responseBody = {
+  "status": "ok"
+}
+
+const responseBodyError = {
+  "status": "error"
+}
+
+/**
+ * Responds to an HTTP request using data from the request body parsed according
+ * to the "content-type" header.
+ *
+ * @param {Object} req Cloud Function request context.
+ * @param {Object} res Cloud Function response context.
+ */
+functions.http('helloHttp', (req, res) => {
+  
+  if (req.headers['content-type'] === "application/json" && req.method === "POST") {
+    let body = req.body
+
+    console.log("Processing Request!")
+    console.log(`Tool: ${body.runs[0].tool.driver.name}`)
+    console.log(`Version: ${body.runs[0].tool.driver.name}`)
+    console.log(`Information Uri: ${body.runs[0].tool.driver.informationUri}`)
+  
+    body.runs[0].results.forEach(element => {
+      console.log("*******************")
+      console.log(`Level: ${element.level}`)
+      console.log(`Message: ${element.message.text}`)
+      console.log(`artifactLocation: ${element.locations[0].physicalLocation.artifactLocation.uri}`)
+    });
+    res.status(201).send(JSON.stringify(responseBody))
+  } else {
+    res.status(400).send(JSON.stringify(responseBodyError))
+  }
+  
+});

--- a/endpoint/package.json
+++ b/endpoint/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "endpoint",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",  
+    "start": "npx @google-cloud/functions-framework --target=helloHttp"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.3.0"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ parser.add_argument('--china', {
 parser.add_argument('--csv', { help: 'Output: CSV file' });
 parser.add_argument('--json', { help: 'Output: JSON file' });
 parser.add_argument('--junit', { help: 'Output: Junit file' });
+parser.add_argument('--sarifEndpoint', { help: 'Output: Sarif JSON to a predifined user endpoint' });
 parser.add_argument('--console', {
     help: 'Console output format. Default: table',
     choices: ['none', 'text', 'table'],

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   "dependencies": {
     "@alicloud/pop-core": "^1.7.10",
     "@azure/data-tables": "^13.2.2",
-    "@azure/storage-blob": "^12.14.0",
     "@azure/storage-file-share": "^12.14.0",
     "@azure/storage-queue": "^12.13.0",
+    "@azure/storage-blob": "^12.14.0",
     "@octokit/app": "^3.0.0",
     "@octokit/request": "^3.0.3",
     "@octokit/rest": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
   "dependencies": {
     "@alicloud/pop-core": "^1.7.10",
     "@azure/data-tables": "^13.2.2",
+    "@azure/storage-blob": "^12.14.0",
     "@azure/storage-file-share": "^12.14.0",
     "@azure/storage-queue": "^12.13.0",
-    "@azure/storage-blob": "^12.14.0",
+    "@google-cloud/functions-framework": "^3.3.0",
     "@octokit/app": "^3.0.0",
     "@octokit/request": "^3.0.3",
     "@octokit/rest": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   "dependencies": {
     "@alicloud/pop-core": "^1.7.10",
     "@azure/data-tables": "^13.2.2",
+    "@azure/storage-blob": "^12.14.0",
     "@azure/storage-file-share": "^12.14.0",
     "@azure/storage-queue": "^12.13.0",
-    "@azure/storage-blob": "^12.14.0",
     "@octokit/app": "^3.0.0",
     "@octokit/request": "^3.0.3",
     "@octokit/rest": "^16.3.2",
@@ -51,6 +51,7 @@
     "argparse": "^2.0.0",
     "async": "^2.6.1",
     "aws-sdk": "^2.1338.0",
+    "axios": "^1.5.0",
     "azure-storage": "^2.10.3",
     "csv-write-stream": "^2.0.0",
     "fast-safe-stringify": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@azure/storage-blob": "^12.14.0",
     "@azure/storage-file-share": "^12.14.0",
     "@azure/storage-queue": "^12.13.0",
-    "@google-cloud/functions-framework": "^3.3.0",
     "@octokit/app": "^3.0.0",
     "@octokit/request": "^3.0.3",
     "@octokit/rest": "^16.3.2",

--- a/postprocess/output.js
+++ b/postprocess/output.js
@@ -491,7 +491,7 @@ module.exports = {
             collectionOutput = this.createCollection(streamColl, settings);
         }
 
-        if (settings.sarifEndpoint) {
+        if (settings.json && settings.sarifEndpoint) {
             var streamJson = fs.createWriteStream(settings.json);
             outputs.push(this.createSarifEndpoint(streamJson, settings));
         }

--- a/postprocess/output.js
+++ b/postprocess/output.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var ttytable = require('tty-table');
+var axios = require('axios');
 
 function exchangeStatusWord(result) {
     if (result.status === 0) return 'OK';
@@ -154,6 +155,79 @@ module.exports = {
     
             close: function() {
                 log(`INFO: Sending SARIF report to ${settings.sarifEndpoint}`, settings);
+
+                var sarif = {
+                    "version": "2.1.0",
+                    "$schema": "http://json.schemastore.org/sarif-2.1.0",
+                    "runs": [
+                      {
+                        "tool": {
+                          "driver": {
+                            "name": "Applaudo Sploit",
+                            "version": "1.0",
+                            "informationUri": "https://applaudo.com/"
+                          }
+                        },
+                        "results": []
+                      }
+                    ]
+                  }
+
+                results.forEach(result=>{
+                    var addResult = {
+                        "level": "",
+                        "message": {
+                          "text": ""
+                        },
+                        "locations": [
+                          {
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": "",
+                              }
+                            }
+                          }
+                        ],
+                        "ruleId": ""
+                      }
+
+                    addResult.level = result.status
+                    addResult.message.text = result.message
+                    addResult.locations[0].physicalLocation.artifactLocation.uri = result.resource
+                    addResult.ruleId = `${result.category.toUpperCase()}-${result.plugin.toUpperCase()}`
+
+
+                    sarif.runs[0].results.push(addResult)
+                })
+
+                var result = {
+                    "level": "",
+                    "message": {
+                      "text": ""
+                    },
+                    "locations": [
+                      {
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "",
+                          }
+                        }
+                      }
+                    ],
+                    "ruleId": ""
+                  }
+
+                  console.log("Response from sarif endpoint: ")
+                  axios.post(settings.sarifEndpoint,JSON.stringify(sarif, null, 2), {headers: {
+                    'content-type': 'application/json'
+                  }})
+                  .then(function (response) {
+                    console.log(response.data);
+                  })
+                  .catch(function (error) {
+                    console.log(error.data);
+                  });
+
             }
         };
     },


### PR DESCRIPTION
Adding support to handle an endpoint to send the sarif report when running the app the following way

```bash
node index.js --cloud aws --config ./config.js --json=output.sarif.json --sarifEndpoint=http://google.com --console=none --plugin s3Encryption
                              |
  ApplaudoSploit by Applaudo Studios (v1.0.0-beta.1)
  Cloud security auditing for AWS, Azure, GCP, Oracle, and GitHub

  Based on cloudSploit by Aqua Security, Ltd.

INFO: Using CloudSploit config file: ./config.js
INFO: Skipping AWS pagination mode
INFO: Testing plugin: S3 Bucket Encryption Enforcement
INFO: Determining API calls to make...
INFO: Found 6 API calls to make for aws plugins
INFO: Collecting metadata. This may take several minutes...
(node:40080) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: Metadata collection complete. Analyzing...
INFO: Analysis complete. Scan report to follow...
INFO: SARIF JSON file written to output.sarif.json
INFO: Sending SARIF report to http://google.com
INFO: Console output suppressed because "console" setting was "none"
INFO: Scan complete
```

The logs will show the following:

```bash
INFO: SARIF JSON file written to output.sarif.json
INFO: Sending SARIF report to http://google.com
```

This will allow to define an endpoint where we can process the sarif data